### PR TITLE
Split out intermediate results from BBHash struct to new lvlData struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 # Stuff to ignore for now
 bbhash_snarl_test.go
 marshal_hack.go
+benchmark-results

--- a/.vscode/bbhash.txt
+++ b/.vscode/bbhash.txt
@@ -1,4 +1,5 @@
 bbhash
+benchstat
 Boba
 Chewbacca
 Chikhi

--- a/bbhash_parallel.go
+++ b/bbhash_parallel.go
@@ -1,0 +1,6 @@
+package bbhash
+
+func NewParallel(gamma float64, salt uint64, keys []uint64) (*BBHash, error) {
+	// TODO: this is just a placeholder for now
+	return NewSequential(gamma, salt, keys)
+}

--- a/bbhash_reverse_map.go
+++ b/bbhash_reverse_map.go
@@ -9,7 +9,7 @@ import (
 // The Lookup method can be used to look up the original key for a given hash index.
 // See NewSerial for details on the parameters.
 func NewWithReverseIndex(gamma float64, salt uint64, keys []uint64) (*BBHash, error) {
-	bb, err := NewSerial(gamma, salt, keys)
+	bb, err := NewSequential(gamma, salt, keys)
 	if err != nil {
 		return nil, err
 	}

--- a/bbhash_test.go
+++ b/bbhash_test.go
@@ -48,81 +48,179 @@ func TestSimple(t *testing.T) {
 		keys[i] = fnvHash(s)
 	}
 	salt := rand.New(rand.NewSource(99)).Uint64()
-	bb, err := bbhash.NewSerial(2.0, salt, keys)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Log(bb)
-	keyMap := make(map[uint64]uint64)
-	for keyIndex, key := range keys {
-		hashIndex := bb.Find(key)
-		checkKey(t, keyIndex, key, uint64(len(keys)), hashIndex)
 
-		if x, ok := keyMap[hashIndex]; ok {
-			t.Fatalf("index %d already mapped to key %#x", hashIndex, x)
-		}
-		keyMap[hashIndex] = key
+	tests := []struct {
+		name   string
+		fn     func(gamma float64, salt uint64, keys []uint64) (*bbhash.BBHash, error)
+		keyMap map[uint64]uint64
+	}{
+		{name: "Serial", fn: bbhash.NewSequential},
+		{name: "Parallel", fn: bbhash.NewParallel},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bb, err := test.fn(2.0, salt, keys)
+			if err != nil {
+				t.Fatal(err)
+			}
+			keyMap := make(map[uint64]uint64)
+			for keyIndex, key := range keys {
+				hashIndex := bb.Find(key)
+				checkKey(t, keyIndex, key, uint64(len(keys)), hashIndex)
+
+				if x, ok := keyMap[hashIndex]; ok {
+					t.Fatalf("index %d already mapped to key %#x", hashIndex, x)
+				}
+				keyMap[hashIndex] = key
+			}
+		})
 	}
 }
 
 func TestManyKeys(t *testing.T) {
-	tests := []struct {
-		gamma float64
-		size  int
-	}{
-		{gamma: 2.0, size: 1000},
-		{gamma: 2.0, size: 10000},
-		{gamma: 2.0, size: 100000},
-		{gamma: 2.0, size: 1000000},
-		{gamma: 2.0, size: 10000000},
+	sizes := []int{
+		1000,
+		10_000,
+		100_000,
 	}
-	// Find() is too slow to check 10 million keys; the test will potentially run for 15-20 minutes.
-	const expectedTimeToFind10MillionKeys = 18 * time.Minute
-	deadline, ok := t.Deadline()
+	tests := []struct {
+		name  string
+		gamma float64
+		seed  int
+		fn    func(gamma float64, salt uint64, keys []uint64) (*bbhash.BBHash, error)
+	}{
+		{name: "Sequential", gamma: 1.0, seed: 123, fn: bbhash.NewSequential},
+		{name: "Parallel__", gamma: 1.0, seed: 123, fn: bbhash.NewParallel},
+		{name: "Sequential", gamma: 1.5, seed: 123, fn: bbhash.NewSequential},
+		{name: "Parallel__", gamma: 1.5, seed: 123, fn: bbhash.NewParallel},
+		{name: "Sequential", gamma: 2.0, seed: 123, fn: bbhash.NewSequential},
+		{name: "Parallel__", gamma: 2.0, seed: 123, fn: bbhash.NewParallel},
+		{name: "Sequential", gamma: 2.5, seed: 123, fn: bbhash.NewSequential},
+		{name: "Parallel__", gamma: 2.5, seed: 123, fn: bbhash.NewParallel},
+		{name: "Sequential", gamma: 3.0, seed: 123, fn: bbhash.NewSequential},
+		{name: "Parallel__", gamma: 3.0, seed: 123, fn: bbhash.NewParallel},
+		{name: "Sequential", gamma: 5.0, seed: 123, fn: bbhash.NewSequential},
+		{name: "Parallel__", gamma: 5.0, seed: 123, fn: bbhash.NewParallel},
+	}
 
 	salt := rand.New(rand.NewSource(99)).Uint64()
 	for _, tt := range tests {
-		keys := generateKeys(tt.size, 99)
-		t.Run(fmt.Sprintf("gamma=%.1f/keys=%d", tt.gamma, tt.size), func(t *testing.T) {
-			bb, err := bbhash.NewSerial(tt.gamma, salt, keys)
-			if err != nil {
-				t.Fatal(err)
-			}
-			t.Log(bb)
-			// Skip test key sizes that are too large for the test to finish in time.
-			// If ok == false, the test has no deadline (timeout=0), in which case we don't skip the test.
-			if tt.size > 1_000_000 && ok && time.Until(deadline) < expectedTimeToFind10MillionKeys {
-				t.Skip("test will timeout before it can finish; use -timeout=0 or -timeout=20m to run it anyway")
-			}
-			for keyIndex, key := range keys {
-				hashIndex := bb.Find(key)
-				checkKey(t, keyIndex, key, uint64(len(keys)), hashIndex)
-			}
-		})
+		for _, size := range sizes {
+			keys := generateKeys(size, tt.seed)
+			t.Run(fmt.Sprintf("name=%s/gamma=%0.1f/keys=%d", tt.name, tt.gamma, size), func(t *testing.T) {
+				bb, err := tt.fn(tt.gamma, salt, keys)
+				if err != nil {
+					t.Fatal(err)
+				}
+				keyMap := make(map[uint64]uint64)
+				for keyIndex, key := range keys {
+					hashIndex := bb.Find(key)
+					checkKey(t, keyIndex, key, uint64(len(keys)), hashIndex)
+					if x, ok := keyMap[hashIndex]; ok {
+						t.Fatalf("index %d already mapped to key %#x", hashIndex, x)
+					}
+					keyMap[hashIndex] = key
+				}
+			})
+		}
+	}
+}
+
+func TestSlow(t *testing.T) {
+	// We only run this test if -timeout=0 is specified (ok == false).
+	if _, ok := t.Deadline(); ok {
+		// Find() is slow when checking more than 1 million keys
+		t.Skip("Skipping test; use -timeout=0 to run it anyway")
+	}
+	// emit progress every 100k keys
+	const progressInterval = 100_000
+	sizes := []int{
+		1_000_000,
+		10_000_000,
+		100_000_000,
+	}
+	tests := []struct {
+		name  string
+		gamma float64
+		seed  int
+		fn    func(gamma float64, salt uint64, keys []uint64) (*bbhash.BBHash, error)
+	}{
+		{name: "Sequential", gamma: 2.0, seed: 99, fn: bbhash.NewSequential},
+		// {name: "Parallel__", gamma: 2.0, seed: 99, fn: bbhash.NewParallel},
+	}
+
+	salt := rand.New(rand.NewSource(99)).Uint64()
+	for _, tt := range tests {
+		for _, size := range sizes {
+			keys := generateKeys(size, tt.seed)
+			t.Run(fmt.Sprintf("name=%s/gamma=%0.1f/keys=%d", tt.name, tt.gamma, size), func(t *testing.T) {
+				bb, err := tt.fn(tt.gamma, salt, keys)
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Log(bb)
+				keyMap := make(map[uint64]uint64, size)
+				start := time.Now()
+				for keyIndex, key := range keys {
+					if keyIndex%progressInterval == 0 {
+						duration := time.Since(start)
+						if duration > time.Second {
+							duration = duration.Truncate(time.Second)
+							expectedTimeToFinish := time.Duration(size/progressInterval) * duration
+							t.Logf("Progress (keyIndex=%9d) Duration: %s Expect to finish in %s", keyIndex, duration, expectedTimeToFinish)
+						}
+						start = time.Now()
+					}
+					hashIndex := bb.Find(key)
+					checkKey(t, keyIndex, key, uint64(len(keys)), hashIndex)
+					if x, ok := keyMap[hashIndex]; ok {
+						t.Fatalf("index %d already mapped to key %#x", hashIndex, x)
+					}
+					keyMap[hashIndex] = key
+				}
+			})
+		}
 	}
 }
 
 var bbSink *bbhash.BBHash
 
-func BenchmarkNewSerial(b *testing.B) {
+// BenchmarkNewBBHash benchmarks the creation of a new BBHash with sequential and parallel.
+// Run with:
+//
+// go test -run x -bench BenchmarkNewBBHash -count 10 > new.txt
+//
+// Then compare with:
+//
+// benchstat -col /name new.txt
+func BenchmarkNewBBHash(b *testing.B) {
+	sizes := []int{
+		1000,
+		10_000,
+		100_000,
+		1_000_000,
+		// 10_000_000,
+		// 100_000_000,
+		// 1_000_000_000,
+	}
 	tests := []struct {
-		gamma float64
-		size  int
+		name string
+		fn   func(gamma float64, salt uint64, keys []uint64) (*bbhash.BBHash, error)
 	}{
-		{gamma: 2.0, size: 1000},
-		{gamma: 2.0, size: 10000},
-		{gamma: 2.0, size: 100000},
-		{gamma: 2.0, size: 1000000},
+		{name: "Sequential", fn: bbhash.NewSequential},
+		// {name: "Parallel__", fn: bbhash.NewParallel},
 	}
 	salt := rand.New(rand.NewSource(99)).Uint64()
 	for _, tt := range tests {
-		keys := generateKeys(tt.size, 99)
-		b.Run(fmt.Sprintf("gamma=%.1f/keys=%d", tt.gamma, tt.size), func(b *testing.B) {
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				bbSink, _ = bbhash.NewSerial(tt.gamma, salt, keys)
-			}
-		})
+		for _, size := range sizes {
+			keys := generateKeys(size, 99)
+			b.Run(fmt.Sprintf("name=%s/keys=%d", tt.name, size), func(b *testing.B) {
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					bbSink, _ = tt.fn(2.0, salt, keys)
+				}
+			})
+		}
 	}
 }
 
@@ -139,7 +237,7 @@ func BenchmarkFind(b *testing.B) {
 	salt := rand.New(rand.NewSource(99)).Uint64()
 	for _, tt := range tests {
 		keys := generateKeys(tt.size, 99)
-		bb, err := bbhash.NewSerial(tt.gamma, salt, keys)
+		bb, err := bbhash.NewSequential(tt.gamma, salt, keys)
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
Split out intermediate results from BBHash struct into lvlData.
Benchmark results indicate that this change does not impact the CPU time and allocations.

