### PR TITLE
Avoid slice of pointers

### DIFF
--- a/.vscode/bbhash.txt
+++ b/.vscode/bbhash.txt
@@ -21,6 +21,7 @@ Gryski
 Guillaume
 Herle's
 Hutt
+IPFS
 Jabba
 Kenobi
 Keymap

--- a/bbhash.go
+++ b/bbhash.go
@@ -14,8 +14,8 @@ type BBHash struct {
 	reverseMap []uint64    // index -> key (only filled if needed)
 }
 
-func newBBHash(initialLevels int) *BBHash {
-	return &BBHash{
+func newBBHash(initialLevels int) BBHash {
+	return BBHash{
 		bits: make([]bitVector, 0, initialLevels),
 	}
 }
@@ -31,7 +31,7 @@ func newBBHash(initialLevels int) *BBHash {
 // If the key is not in the original key set, two things can happen:
 // 1. The return value is 0, representing that the key was not in the original key set.
 // 2. The return value is in the expected range [1, len(keys)], but is a false positive.
-func (bb *BBHash) Find(key uint64) uint64 {
+func (bb BBHash) Find(key uint64) uint64 {
 	for lvl, bv := range bb.bits {
 		i := fast.Hash(uint64(lvl), key) % bv.size()
 		if bv.isSet(i) {
@@ -43,7 +43,7 @@ func (bb *BBHash) Find(key uint64) uint64 {
 
 // Key returns the key for the given index.
 // The index must be in the range [1, len(keys)], otherwise 0 is returned.
-func (bb *BBHash) Key(index uint64) uint64 {
+func (bb BBHash) Key(index uint64) uint64 {
 	if bb.reverseMap == nil || index == 0 || int(index) >= len(bb.reverseMap) {
 		return 0
 	}

--- a/bbhash.go
+++ b/bbhash.go
@@ -9,14 +9,14 @@ import (
 
 // BBHash represents a minimal perfect hash for a set of keys.
 type BBHash struct {
-	bits       []*bitVector // bit vectors for each level
-	ranks      []uint64     // total rank for each level
-	reverseMap []uint64     // index -> key (only filled if needed)
+	bits       []bitVector // bit vectors for each level
+	ranks      []uint64    // total rank for each level
+	reverseMap []uint64    // index -> key (only filled if needed)
 }
 
 func newBBHash(initialLevels int) *BBHash {
 	return &BBHash{
-		bits: make([]*bitVector, 0, initialLevels),
+		bits: make([]bitVector, 0, initialLevels),
 	}
 }
 

--- a/bbhash_fmt.go
+++ b/bbhash_fmt.go
@@ -124,7 +124,7 @@ func (bb BBHash) BitVectors(size int) string {
 	b.WriteString(fmt.Sprintf("var bitVectors%d = [][]uint64{\n", size))
 	for lvl, bv := range bb.bits {
 		b.WriteString(fmt.Sprintf("// Level %d:\n{\n", lvl))
-		for _, v := range bv.v {
+		for _, v := range bv {
 			b.WriteString(fmt.Sprintf("%#016x,\n", v))
 		}
 		b.WriteString("},\n")
@@ -141,8 +141,8 @@ func (bb BBHash) BitVectors(size int) string {
 func (bb BBHash) LevelVectors() [][]uint64 {
 	m := make([][]uint64, 0, len(bb.bits))
 	for _, bv := range bb.bits {
-		m = append(m, make([]uint64, len(bv.v)))
-		copy(m[len(m)-1], bv.v)
+		m = append(m, make([]uint64, len(bv)))
+		copy(m[len(m)-1], bv)
 	}
 	return m
 }

--- a/bbhash_fmt.go
+++ b/bbhash_fmt.go
@@ -119,9 +119,9 @@ func (bb BBHash) falsePositiveRate() float64 {
 
 // BitVectors returns a Go slice for BBHash's per-level bit vectors.
 // This is intended for testing and debugging; no guarantees are made about the format.
-func (bb BBHash) BitVectors(size int) string {
+func (bb BBHash) BitVectors(varName string) string {
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("var bitVectors%d = [][]uint64{\n", size))
+	b.WriteString(fmt.Sprintf("var %s = [][]uint64{\n", varName))
 	for lvl, bv := range bb.bits {
 		b.WriteString(fmt.Sprintf("// Level %d:\n{\n", lvl))
 		for _, v := range bv {

--- a/bbhash_fmt2.go
+++ b/bbhash_fmt2.go
@@ -95,7 +95,7 @@ func (bb BBHash2) BitVectors(varName string) string {
 		b.WriteString(fmt.Sprintf("// Partition %d:\n{\n", partition))
 		for lvl, bv := range bx.bits {
 			b.WriteString(fmt.Sprintf("// Level %d:\n{\n", lvl))
-			for _, v := range bv.v {
+			for _, v := range bv {
 				b.WriteString(fmt.Sprintf("%#016x,\n", v))
 			}
 			b.WriteString("},\n")

--- a/bbhash_marshal.go
+++ b/bbhash_marshal.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 )
 
-// MarshalBinary implements the encoding.BinaryMarshaler interface.
+// MarshalBinary implements the [encoding.BinaryMarshaler] interface.
 func (bb BBHash) MarshalBinary() ([]byte, error) {
 	// Header: 1 x 64-bit words:
 	//   n - number of bit vectors (= number of levels)
@@ -17,7 +17,7 @@ func (bb BBHash) MarshalBinary() ([]byte, error) {
 
 	numBitVectors := uint64(len(bb.bits))
 	if numBitVectors == 0 {
-		return nil, errors.New("BBHash.MarshalBinary: invalid length")
+		return nil, errors.New("BBHash.MarshalBinary: no data")
 	}
 
 	// Write header
@@ -38,11 +38,12 @@ func (bb BBHash) MarshalBinary() ([]byte, error) {
 
 	// We don't store the rank vector, since we can re-compute it
 	// when we unmarshal the bit vectors.
+	// We also don't include the reverse map; it is not meant to be serialized.
 
 	return buf.Bytes(), nil
 }
 
-// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
+// UnmarshalBinary implements the [encoding.BinaryUnmarshaler] interface.
 func (bb *BBHash) UnmarshalBinary(data []byte) error {
 	// Make a copy of data, since we will be modifying buf's slice indices
 	buf := data
@@ -56,12 +57,12 @@ func (bb *BBHash) UnmarshalBinary(data []byte) error {
 		return fmt.Errorf("BBHash.UnmarshalBinary: invalid number of bit vectors %d (max %d)", numBitVectors, maxLevel)
 	}
 	*bb = BBHash{} // Not strictly necessary, but seems to be recommended practice
-	bb.bits = make([]*bitVector, numBitVectors)
+	bb.bits = make([]bitVector, numBitVectors)
 	buf = buf[8:] // Move past header
 
 	// Read bit vectors for each level
 	for i := uint64(0); i < numBitVectors; i++ {
-		bv := &bitVector{}
+		bv := bitVector{}
 		if err := bv.UnmarshalBinary(buf); err != nil {
 			return err
 		}

--- a/bbhash_partitioned.go
+++ b/bbhash_partitioned.go
@@ -6,7 +6,7 @@ import (
 
 // BBHash2 represents a minimal perfect hash for a set of keys.
 type BBHash2 struct {
-	partitions []*BBHash
+	partitions []BBHash
 	offsets    []int
 }
 
@@ -41,7 +41,7 @@ func New(keys []uint64, opts ...Options) (*BBHash2, error) {
 			return nil, err
 		}
 		return &BBHash2{
-			partitions: []*BBHash{bb},
+			partitions: []BBHash{bb},
 			offsets:    []int{0},
 		}, nil
 	}
@@ -60,7 +60,7 @@ func newPartitioned(keys []uint64, o *options) (*BBHash2, error) {
 		partitionKeys[i] = append(partitionKeys[i], k)
 	}
 	bb := &BBHash2{
-		partitions: make([]*BBHash, o.partitions),
+		partitions: make([]BBHash, o.partitions),
 		offsets:    make([]int, o.partitions),
 	}
 	grp := &errgroup.Group{}
@@ -92,14 +92,14 @@ func newPartitioned(keys []uint64, o *options) (*BBHash2, error) {
 // If the key is not in the original key set, two things can happen:
 // 1. The return value is 0, representing that the key was not in the original key set.
 // 2. The return value is in the expected range [1, len(keys)], but is a false positive.
-func (bb *BBHash2) Find(key uint64) uint64 {
+func (bb BBHash2) Find(key uint64) uint64 {
 	i := key % uint64(len(bb.partitions))
 	return bb.partitions[i].Find(key) + uint64(bb.offsets[i])
 }
 
 // Key returns the key for the given index.
 // The index must be in the range [1, len(keys)], otherwise 0 is returned.
-func (bb *BBHash2) Key(index uint64) uint64 {
+func (bb BBHash2) Key(index uint64) uint64 {
 	for _, b := range bb.partitions {
 		if index < uint64(len(b.reverseMap)) {
 			return b.reverseMap[index]
@@ -111,15 +111,15 @@ func (bb *BBHash2) Key(index uint64) uint64 {
 
 // Partitions returns the number of partitions in the BBHash2.
 // This is mainly useful for testing and may be removed in the future.
-func (bb *BBHash2) Partitions() int {
+func (bb BBHash2) Partitions() int {
 	return len(bb.partitions)
 }
 
 // SinglePartition returns the underlying BBHash if it contains a single partition.
 // If there are multiple partitions, it returns nil.
-func (bb *BBHash2) SinglePartition() *BBHash {
+func (bb BBHash2) SinglePartition() *BBHash {
 	if len(bb.partitions) == 1 {
-		return bb.partitions[0]
+		return &bb.partitions[0]
 	}
 	return nil
 }

--- a/bcvector.go
+++ b/bcvector.go
@@ -2,15 +2,15 @@ package bbhash
 
 // bcVector represents a combined bit and collision vector.
 type bcVector struct {
-	v []uint64
-	c []uint64
+	v bitVector
+	c bitVector
 }
 
 // newBCVector returns a combined bit and collision vector with the given number of words.
 func newBCVector(words uint64) *bcVector {
 	return &bcVector{
-		v: make([]uint64, words),
-		c: make([]uint64, words),
+		v: make(bitVector, words),
+		c: make(bitVector, words),
 	}
 }
 
@@ -19,7 +19,7 @@ func newBCVector(words uint64) *bcVector {
 func (b *bcVector) nextLevel(words uint64) {
 	b.c = b.c[:words]
 	clear(b.c)
-	b.v = make([]uint64, words)
+	b.v = make(bitVector, words)
 }
 
 // reset resizes the bit and collision vector to the given number of words,
@@ -32,7 +32,7 @@ func (b *bcVector) reset(words uint64) {
 }
 
 func (b *bcVector) bitVector() bitVector {
-	return bitVector(b.v)
+	return b.v
 }
 
 // size returns the number of bits this bit vector has allocated.

--- a/bcvector.go
+++ b/bcvector.go
@@ -31,8 +31,8 @@ func (b *bcVector) reset(words uint64) {
 	clear(b.v)
 }
 
-func (b *bcVector) bitVector() *bitVector {
-	return &bitVector{v: b.v}
+func (b *bcVector) bitVector() bitVector {
+	return bitVector(b.v)
 }
 
 // size returns the number of bits this bit vector has allocated.

--- a/bitvector.go
+++ b/bitvector.go
@@ -7,15 +7,11 @@ import (
 )
 
 // bitVector represents a bit vector in an efficient manner.
-type bitVector struct {
-	v []uint64
-}
+type bitVector []uint64
 
 // newBitVector creates a bit vector with the given number of words.
-func newBitVector(words uint64) *bitVector {
-	return &bitVector{
-		v: make([]uint64, words),
-	}
+func newBitVector(words uint64) bitVector {
+	return make(bitVector, words)
 }
 
 // words returns the number of words the bit vector needs to hold size bits, with expansion factor gamma.
@@ -25,61 +21,61 @@ func words(size int, gamma float64) uint64 {
 }
 
 // size returns the number of bits this bit vector has allocated.
-func (b *bitVector) size() uint64 {
-	return uint64(len(b.v) * 64)
+func (b bitVector) size() uint64 {
+	return uint64(len(b) * 64)
 }
 
 // words returns the number of 64-bit words this bit vector has allocated.
-func (b *bitVector) words() uint64 {
-	return uint64(len(b.v))
+func (b bitVector) words() uint64 {
+	return uint64(len(b))
 }
 
 // set sets the bit at position i.
-func (b *bitVector) set(i uint64) {
-	b.v[i/64] |= 1 << (i % 64)
+func (b bitVector) set(i uint64) {
+	b[i/64] |= 1 << (i % 64)
 }
 
 // unset zeroes the bit at position i.
-func (b *bitVector) unset(i uint64) {
-	b.v[i/64] &^= 1 << (i % 64)
+func (b bitVector) unset(i uint64) {
+	b[i/64] &^= 1 << (i % 64)
 }
 
 // isSet returns true if the bit at position i is set.
-func (b *bitVector) isSet(i uint64) bool {
-	return b.v[i/64]&(1<<(i%64)) != 0
+func (b bitVector) isSet(i uint64) bool {
+	return b[i/64]&(1<<(i%64)) != 0
 }
 
 // reset reduces the bit vector's size to words and zeroes the elements.
-func (b *bitVector) reset(words uint64) {
-	b.v = b.v[:words]
-	clear(b.v)
+func (b bitVector) reset(words uint64) {
+	b = b[:words]
+	clear(b)
 }
 
 // onesCount returns the number of one bits ("population count") in the bit vector.
-func (b *bitVector) onesCount() uint64 {
+func (b bitVector) onesCount() uint64 {
 	var p int
-	for i := range b.v {
-		p += bits.OnesCount64(b.v[i])
+	for i := range b {
+		p += bits.OnesCount64(b[i])
 	}
 	return uint64(p)
 }
 
 // rank returns the number of one bits in the bit vector up to position i.
-func (b *bitVector) rank(i uint64) uint64 {
+func (b bitVector) rank(i uint64) uint64 {
 	x := i / 64
 	y := i % 64
 
 	var r int
 	for k := uint64(0); k < x; k++ {
-		r += bits.OnesCount64(b.v[k])
+		r += bits.OnesCount64(b[k])
 	}
-	v := b.v[x]
+	v := b[x]
 	r += bits.OnesCount64(v << (64 - y))
 	return uint64(r)
 }
 
 // String returns a string representation of the bit vector.
-func (b *bitVector) String() string {
+func (b bitVector) String() string {
 	var buf strings.Builder
 	for i := uint64(0); i < b.size(); i++ {
 		if b.isSet(i) {
@@ -93,7 +89,7 @@ func (b *bitVector) String() string {
 
 // stringList returns a string list of true positions in the bit vector.
 // Mainly useful for debugging with smaller bit vectors.
-func (b *bitVector) stringList() string {
+func (b bitVector) stringList() string {
 	var buf strings.Builder
 	buf.WriteString("(")
 	for i := uint64(0); i < b.size(); i++ {

--- a/bitvector.go
+++ b/bitvector.go
@@ -9,11 +9,6 @@ import (
 // bitVector represents a bit vector in an efficient manner.
 type bitVector []uint64
 
-// newBitVector creates a bit vector with the given number of words.
-func newBitVector(words uint64) bitVector {
-	return make(bitVector, words)
-}
-
 // words returns the number of words the bit vector needs to hold size bits, with expansion factor gamma.
 func words(size int, gamma float64) uint64 {
 	sz := uint64(float64(size) * gamma)

--- a/bitvector_marshal.go
+++ b/bitvector_marshal.go
@@ -7,13 +7,13 @@ import (
 )
 
 // marshaledLength returns the number of bytes needed to marshal the bit vector.
-func (b *bitVector) marshaledLength() int {
+func (b bitVector) marshaledLength() int {
 	const uint64bytes = 8
-	return uint64bytes * (1 + len(b.v))
+	return uint64bytes * (1 + len(b))
 }
 
-// MarshalBinary implements the encoding.BinaryMarshaler interface.
-func (b *bitVector) MarshalBinary() ([]byte, error) {
+// MarshalBinary implements the [encoding.BinaryMarshaler] interface.
+func (b bitVector) MarshalBinary() ([]byte, error) {
 	out := make([]byte, b.marshaledLength())
 	// Make a copy of out, since we will be modifying buf's slice indices
 	buf := out
@@ -23,7 +23,7 @@ func (b *bitVector) MarshalBinary() ([]byte, error) {
 	buf = buf[8:]
 
 	// Write the bit vector entries to the out buffer
-	for _, v := range b.v {
+	for _, v := range b {
 		binary.LittleEndian.PutUint64(buf[:8], v)
 		buf = buf[8:]
 	}
@@ -31,7 +31,7 @@ func (b *bitVector) MarshalBinary() ([]byte, error) {
 	return out, nil
 }
 
-// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
+// UnmarshalBinary implements the [encoding.BinaryUnmarshaler] interface.
 func (b *bitVector) UnmarshalBinary(data []byte) error {
 	// Make a copy of data, since we will be modifying buf's slice indices
 	buf := data
@@ -45,7 +45,7 @@ func (b *bitVector) UnmarshalBinary(data []byte) error {
 		return fmt.Errorf("bitVector.UnmarshalBinary: invalid length %d", words)
 	}
 
-	b.v = make([]uint64, words)
+	*b = make(bitVector, words) // modify b in place
 	buf = buf[8:]
 
 	// Read the bit vector entries
@@ -53,7 +53,7 @@ func (b *bitVector) UnmarshalBinary(data []byte) error {
 		if len(buf) < 8 {
 			return errors.New("bitVector.UnmarshalBinary: not enough data to read bit vector entry")
 		}
-		b.v[i] = binary.LittleEndian.Uint64(buf[:8])
+		(*b)[i] = binary.LittleEndian.Uint64(buf[:8])
 		buf = buf[8:]
 	}
 

--- a/bitvector_marshal_test.go
+++ b/bitvector_marshal_test.go
@@ -1,29 +1,30 @@
 package bbhash
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestMarshalUnmarshalBitVector(t *testing.T) {
-	bv := newBitVector(3)
-	bv.v = []uint64{42, 84, 168, 12, 3, 234, 12, 34, 12, 45, 4, 54, 44, 4, 43, 42, 23, 232, 35, 232, 67, 6, 2323, 9129123, 3232, 5, 45345, 345, 234, 23, 1232}
+	bv := bitVector{42, 84, 168, 12, 3, 234, 12, 34, 12, 45, 4, 54, 44, 4, 43, 42, 23, 232, 35, 232, 67, 6, 2323, 9129123, 3232, 5, 45345, 345, 234, 23, 1232}
 
 	data, err := bv.MarshalBinary()
 	if err != nil {
 		t.Fatalf("Failed to marshal: %v", err)
 	}
 
-	newBv := &bitVector{}
+	newBv := bitVector{}
 	err = newBv.UnmarshalBinary(data)
 	if err != nil {
 		t.Fatalf("Failed to unmarshal: %v", err)
 	}
 
-	if len(newBv.v) != len(bv.v) {
-		t.Fatalf("Length mismatch: got %d, want %d", len(newBv.v), len(bv.v))
+	if len(newBv) != len(bv) {
+		t.Fatalf("Length mismatch: got %d, want %d", len(newBv), len(bv))
 	}
 
-	for i, val := range bv.v {
-		if newBv.v[i] != val {
-			t.Fatalf("Value mismatch at index %d: got %d, want %d", i, newBv.v[i], val)
+	for i, val := range bv {
+		if newBv[i] != val {
+			t.Fatalf("Value mismatch at index %d: got %d, want %d", i, newBv[i], val)
 		}
 	}
 }

--- a/bitvector_test.go
+++ b/bitvector_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestSetIsSet(t *testing.T) {
 	const words = 50
-	bv := newBitVector(words)
+	bv := make(bitVector, words)
 
 	for i := uint64(0); i < bv.size(); i++ {
 		if bv.isSet(i) {


### PR DESCRIPTION
This refactors bitVector to be a `type bitVector []uint64` instead of a struct with a `v []uint64` field. This allows to avoid unnecessary indirections in the code. This also removes the pointer from `[]*bitVector` from the BBHash struct (becoming `[]bitVector`), since this is also an unnecessary indirection. Moreover, we also removed the pointer receiver for all BBHash and BBHash2 methods that are lookup only. Moreover, the BBHash2 now has a straight []BBHash for the partitions instead of []*BBHash, since the slice entries is also actually a pointer, avoiding another redirection. Finally, we replace the `[]uint64` for the v and c in the `bcVector` with two instances of `bitVector`.

These changes appear to allocate a bit more (for some unknown reason), but allocates much less often and is slightly faster in some cases. But never degrades in performance.

Fixes #16

