### PR TITLE
Improves marshaling space requirement

### DIFF
--- a/bbhash_fmt.go
+++ b/bbhash_fmt.go
@@ -12,7 +12,7 @@ func (bb BBHash) String() string {
 	b.WriteString(fmt.Sprintf("BBHash(gamma=%3.1f, entries=%d, levels=%d, mem bits=%d, wire bits=%d, size=%s, bits per key=%3.1f, false positive rate=%.2f)\n",
 		bb.gamma(), bb.entries(), bb.Levels(), bb.numBits(), bb.wireBits(), bb.space(), bb.BitsPerKey(), bb.falsePositiveRate()))
 	for i, bv := range bb.bits {
-		sz := readableSize(bv.words() * 8)
+		sz := readableSize(uint64(bv.words()) * 8)
 		entries := bv.onesCount()
 		b.WriteString(fmt.Sprintf("  %d: %d / %d bits (%s)\n", i, entries, bv.size(), sz))
 	}

--- a/bbhash_fmt.go
+++ b/bbhash_fmt.go
@@ -80,7 +80,7 @@ func (bb BBHash) numBits() (sz uint64) {
 
 // wireBits returns the number of on-the-wire bits used to represent the minimal perfect hash on the wire.
 func (bb BBHash) wireBits() (sz uint64) {
-	sz += 64 // for the header
+	sz += 8 // one byte for the header: number of bit vectors (levels)
 	for _, bv := range bb.bits {
 		sz += uint64(bv.marshaledLength()) * 8
 	}

--- a/bbhash_fmt2.go
+++ b/bbhash_fmt2.go
@@ -32,6 +32,7 @@ func (bb BBHash2) String() string {
 	return b.String()
 }
 
+// MaxMinLevels returns the maximum and minimum number of levels across all partitions.
 func (bb BBHash2) MaxMinLevels() (max, min int) {
 	max = 0
 	min = 999
@@ -46,25 +47,18 @@ func (bb BBHash2) MaxMinLevels() (max, min int) {
 	return max, min
 }
 
+// BitsPerKey returns the number of bits per key in the minimal perfect hash.
 func (bb BBHash2) BitsPerKey() float64 {
 	return float64(bb.wireBits()) / float64(bb.entries())
 }
 
-func (bb BBHash2) space() string {
-	return readableSize(bb.marshaledLength())
-}
-
-// entries returns the number of entries in the minimal perfect hash.
-func (bb BBHash2) entries() (sz uint64) {
+// LevelVectors returns a slice representation of BBHash2's per-partition, per-level bit vectors.
+func (bb BBHash2) LevelVectors() [][][]uint64 {
+	var vectors [][][]uint64
 	for _, bx := range bb.partitions {
-		sz += bx.entries()
+		vectors = append(vectors, bx.LevelVectors())
 	}
-	return sz
-}
-
-// wireBits returns the number of on-the-wire bits used to represent the minimal perfect hash.
-func (bb BBHash2) wireBits() uint64 {
-	return uint64(bb.marshaledLength()) * 8
+	return vectors
 }
 
 // BitVectors returns a Go slice for BBHash2's per-partition, per-level bit vectors.
@@ -91,11 +85,20 @@ func (bb BBHash2) BitVectors(varName string) string {
 	return string(s)
 }
 
-// LevelVectors returns a slice representation of BBHash2's per-partition, per-level bit vectors.
-func (bb BBHash2) LevelVectors() [][][]uint64 {
-	var vectors [][][]uint64
+// entries returns the number of entries in the minimal perfect hash.
+func (bb BBHash2) entries() (sz uint64) {
 	for _, bx := range bb.partitions {
-		vectors = append(vectors, bx.LevelVectors())
+		sz += bx.entries()
 	}
-	return vectors
+	return sz
+}
+
+// wireBits returns the number of on-the-wire bits used to represent the minimal perfect hash.
+func (bb BBHash2) wireBits() uint64 {
+	return uint64(bb.marshaledLength()) * 8
+}
+
+// space returns a human-readable string representing the size of the minimal perfect hash.
+func (bb BBHash2) space() string {
+	return readableSize(bb.marshaledLength())
 }

--- a/bbhash_fmt2.go
+++ b/bbhash_fmt2.go
@@ -22,10 +22,10 @@ func (bb BBHash2) String() string {
 			}
 		}
 	}
-	b.WriteString(fmt.Sprintf("BBHash2(entries=%d, levels=%d, mem bits=%d, wire bits=%d, size=%s, bits per key=%3.1f)\n",
-		bb.entries(), len(lvlSz), bb.numBits(), bb.wireBits(), bb.space(), bb.BitsPerKey()))
+	b.WriteString(fmt.Sprintf("BBHash2(entries=%d, levels=%d, bits per key=%3.1f, wire bits=%d, size=%s)\n",
+		bb.entries(), len(lvlSz), bb.BitsPerKey(), bb.wireBits(), bb.space()))
 	for lvl := 0; lvl < len(lvlSz); lvl++ {
-		sz := lvlSz[lvl]
+		sz := int(lvlSz[lvl])
 		entries := lvlEntries[lvl]
 		b.WriteString(fmt.Sprintf("  %d: %d / %d bits (%s)\n", lvl, entries, sz, readableSize(sz/8)))
 	}
@@ -51,40 +51,20 @@ func (bb BBHash2) BitsPerKey() float64 {
 }
 
 func (bb BBHash2) space() string {
-	return readableSize(bb.wireBits() / 8)
+	return readableSize(bb.marshaledLength())
 }
 
-func (bb BBHash2) entries() uint64 {
-	var sz uint64
+// entries returns the number of entries in the minimal perfect hash.
+func (bb BBHash2) entries() (sz uint64) {
 	for _, bx := range bb.partitions {
 		sz += bx.entries()
 	}
 	return sz
 }
 
-// numBits returns the number of in-memory bits used to represent the minimal perfect hash.
-func (bb BBHash2) numBits() (sz uint64) {
-	const sizeOfInt = 64
-	for _, bx := range bb.partitions {
-		sz += bx.numBits()
-		sz += sizeOfInt // to account for the offset
-	}
-	return sz
-}
-
-// wireBits returns the number of on-the-wire bits used to represent the minimal perfect hash on the wire.
-func (bb BBHash2) wireBits() (sz uint64) {
-	if len(bb.partitions) == 1 {
-		// no need to account for the offset since there is only one partition
-		return bb.partitions[0].wireBits()
-	}
-	const sizeOfInt = 64
-	sz += 1 // one byte for the header: number of partitions
-	for _, bx := range bb.partitions {
-		sz += bx.wireBits()
-		sz += sizeOfInt // to account for the offset
-	}
-	return sz
+// wireBits returns the number of on-the-wire bits used to represent the minimal perfect hash.
+func (bb BBHash2) wireBits() uint64 {
+	return uint64(bb.marshaledLength()) * 8
 }
 
 // BitVectors returns a Go slice for BBHash2's per-partition, per-level bit vectors.
@@ -111,7 +91,7 @@ func (bb BBHash2) BitVectors(varName string) string {
 	return string(s)
 }
 
-// LevelVectors returns a slice representation of BBHash's per-partition, per-level bit vectors.
+// LevelVectors returns a slice representation of BBHash2's per-partition, per-level bit vectors.
 func (bb BBHash2) LevelVectors() [][][]uint64 {
 	var vectors [][][]uint64
 	for _, bx := range bb.partitions {

--- a/bbhash_fmt2.go
+++ b/bbhash_fmt2.go
@@ -79,6 +79,7 @@ func (bb BBHash2) wireBits() (sz uint64) {
 		return bb.partitions[0].wireBits()
 	}
 	const sizeOfInt = 64
+	sz += 1 // one byte for the header: number of partitions
 	for _, bx := range bb.partitions {
 		sz += bx.wireBits()
 		sz += sizeOfInt // to account for the offset

--- a/bbhash_fmt_test.go
+++ b/bbhash_fmt_test.go
@@ -1,0 +1,105 @@
+package bbhash
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/relab/bbhash/internal/test"
+)
+
+// Default test parameters.
+var (
+	keySizes        = []int{1000, 10_000, 100_000, 1_000_000}
+	partitionValues = []int{1, 4, 8, 16, 24, 32, 48, 64, 128}
+	gammaValues     = []float64{1.0, 1.5, 2.0}
+)
+
+func TestString(t *testing.T) {
+	for _, size := range keySizes {
+		keys := generateKeys(size, 99)
+		for _, gamma := range gammaValues {
+			for _, partitions := range partitionValues {
+				t.Run(test.Name("", []string{"gamma", "partitions", "keys"}, gamma, partitions, size), func(t *testing.T) {
+					bb2, _ := New(keys, Gamma(gamma), Partitions(partitions))
+					if partitions == 1 {
+						bb := bb2.SinglePartition()
+						if size >= 1_000_000 {
+							// Currently, it is too slow to calculate the false positive rate for 1M keys
+							// See issue #21
+							return
+						}
+						t.Logf("BBHash: %v", bb)
+					}
+					t.Logf("BBHash2: %v", bb2)
+				})
+			}
+		}
+	}
+}
+
+func TestBitsAndLengths(t *testing.T) {
+	for _, size := range keySizes {
+		keys := generateKeys(size, 99)
+		for _, gamma := range gammaValues {
+			for _, partitions := range partitionValues {
+				t.Run(test.Name("", []string{"gamma", "partitions", "keys"}, gamma, partitions, size), func(t *testing.T) {
+					bb2, _ := New(keys, Gamma(gamma), Partitions(partitions))
+					if partitions == 1 {
+						// test also the BBHash implementation when there is a single partition
+						testBitsAndLengths(t, size, bb2.SinglePartition())
+					}
+					testBitsAndLengths(t, size, bb2)
+				})
+			}
+		}
+	}
+}
+
+func testBitsAndLengths(t *testing.T, keyLen int, bb bbhashInternal) {
+	t.Helper()
+
+	wantMarshaledLength := bb.marshaledLength()
+
+	// check that the actual marshaled data length is as expected;
+	// if it is higher than expected, unnecessary allocations are being made
+	data, _ := bb.MarshalBinary()
+	gotMarshaledLength := len(data)
+	if wantMarshaledLength != gotMarshaledLength {
+		t.Errorf("marshaledLength() = %d, want %d", wantMarshaledLength, gotMarshaledLength)
+	}
+
+	wantWireBits := uint64(wantMarshaledLength * 8)
+	gotWireBits := bb.wireBits()
+	if wantWireBits != gotWireBits {
+		t.Errorf("wireBits() = %d, want %d", gotWireBits, wantWireBits)
+	}
+
+	wantBPK := float64(wantWireBits) / float64(keyLen)
+	gotBPK := bb.BitsPerKey()
+	if wantBPK != gotBPK {
+		t.Errorf("BitsPerKey() = %f, want %f", gotBPK, wantBPK)
+	}
+
+	wantEntries := uint64(keyLen)
+	gotEntries := bb.entries()
+	if wantEntries != gotEntries {
+		t.Errorf("entries() = %d, want %d", gotEntries, wantEntries)
+	}
+}
+
+type bbhashInternal interface {
+	marshaledLength() int
+	MarshalBinary() ([]byte, error)
+	wireBits() uint64
+	BitsPerKey() float64
+	entries() uint64
+}
+
+func generateKeys(size, seed int) []uint64 {
+	keys := make([]uint64, size)
+	r := rand.New(rand.NewSource(int64(seed)))
+	for i := range keys {
+		keys[i] = r.Uint64()
+	}
+	return keys
+}

--- a/bbhash_opts.go
+++ b/bbhash_opts.go
@@ -16,7 +16,7 @@ const (
 	maxLevel = 255
 
 	// Maximum number of partitions.
-	maxPartitions = 256
+	maxPartitions = 255
 )
 
 type options struct {

--- a/bbhash_opts.go
+++ b/bbhash_opts.go
@@ -13,7 +13,7 @@ const (
 	// Maximum number of attempts (level) at making a perfect hash function.
 	// Per the paper, each successive level exponentially reduces the
 	// probability of collision.
-	maxLevel = 256
+	maxLevel = 255
 
 	// Maximum number of partitions.
 	maxPartitions = 256

--- a/bbhash_partitioned.go
+++ b/bbhash_partitioned.go
@@ -7,7 +7,7 @@ import (
 // BBHash2 represents a minimal perfect hash for a set of keys.
 type BBHash2 struct {
 	partitions []BBHash
-	offsets    []int
+	offsets    []uint32
 }
 
 // New creates a new BBHash2 for the given keys. The keys must be unique.
@@ -42,7 +42,7 @@ func New(keys []uint64, opts ...Options) (*BBHash2, error) {
 		}
 		return &BBHash2{
 			partitions: []BBHash{bb},
-			offsets:    []int{0},
+			offsets:    []uint32{0},
 		}, nil
 	}
 	return newPartitioned(keys, o)
@@ -61,11 +61,11 @@ func newPartitioned(keys []uint64, o *options) (*BBHash2, error) {
 	}
 	bb := &BBHash2{
 		partitions: make([]BBHash, o.partitions),
-		offsets:    make([]int, o.partitions),
+		offsets:    make([]uint32, o.partitions),
 	}
 	grp := &errgroup.Group{}
 	for offset, j := 0, 0; j < o.partitions; j++ {
-		bb.offsets[j] = offset
+		bb.offsets[j] = uint32(offset)
 		offset += len(partitionKeys[j])
 		grp.Go(func() error {
 			bb.partitions[j] = newBBHash(o.initialLevels)

--- a/bitvector.go
+++ b/bitvector.go
@@ -21,8 +21,8 @@ func (b bitVector) size() uint64 {
 }
 
 // words returns the number of 64-bit words this bit vector has allocated.
-func (b bitVector) words() uint64 {
-	return uint64(len(b))
+func (b bitVector) words() uint32 {
+	return uint32(len(b))
 }
 
 // set sets the bit at position i.


### PR DESCRIPTION
This reduces the amount of bits required to encode various parts of the bit vector, BBHash, and BBHash2. Specifically, it makes the following adjustments:

- encode levels (number of bit vectors) as a single byte
- encode the number of partitions as a single byte
- encode bit vector length as uint32
- encode the offsets vector as uint32 and skip the first entry

Fixes #10

```
goos: darwin
goarch: arm64
pkg: github.com/relab/bbhash
cpu: Apple M2 Max
                                                           │ bench-bpk-before.txt │         bench-bpk-after.txt         │
                                                           │        Bytes         │    Bytes     vs base                │
BBHash2BitsPerKey/gamma=1.0/partitions=1/keys=1000-12                  456.0 ± 0%    398.0 ± 0%  -12.72% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=4/keys=1000-12                  632.0 ± 0%    485.0 ± 0%  -23.26% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=8/keys=1000-12                  832.0 ± 0%    593.0 ± 0%  -28.73% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=16/keys=1000-12                1224.0 ± 0%    805.0 ± 0%  -34.23% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=24/keys=1000-12                1528.0 ± 0%    969.0 ± 0%  -36.58% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=32/keys=1000-12                1.848k ± 0%   1.153k ± 0%  -37.61% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=48/keys=1000-12                2.488k ± 0%   1.521k ± 0%  -38.87% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=64/keys=1000-12                2.952k ± 0%   1.757k ± 0%  -40.48% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=128/keys=1000-12               4.888k ± 0%   2.761k ± 0%  -43.51% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=1/keys=1000-12                  448.0 ± 0%    402.0 ± 0%  -10.27% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=4/keys=1000-12                  664.0 ± 0%    525.0 ± 0%  -20.93% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=8/keys=1000-12                  832.0 ± 0%    609.0 ± 0%  -26.80% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=16/keys=1000-12                1192.0 ± 0%    805.0 ± 0%  -32.47% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=24/keys=1000-12                1496.0 ± 0%    965.0 ± 0%  -35.49% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=32/keys=1000-12                1.848k ± 0%   1.153k ± 0%  -37.61% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=48/keys=1000-12                2.488k ± 0%   1.521k ± 0%  -38.87% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=64/keys=1000-12                2.952k ± 0%   1.757k ± 0%  -40.48% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=128/keys=1000-12               4.888k ± 0%   2.761k ± 0%  -43.51% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=1/keys=1000-12                  496.0 ± 0%    450.0 ± 0%   -9.27% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=4/keys=1000-12                  640.0 ± 0%    521.0 ± 0%  -18.59% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=8/keys=1000-12                  864.0 ± 0%    653.0 ± 0%  -24.42% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=16/keys=1000-12                1208.0 ± 0%    825.0 ± 0%  -31.71% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=24/keys=1000-12                1.528k ± 0%   1.013k ± 0%  -33.70% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=32/keys=1000-12                1.920k ± 0%   1.233k ± 0%  -35.78% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=48/keys=1000-12                2.488k ± 0%   1.521k ± 0%  -38.87% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=64/keys=1000-12                2.952k ± 0%   1.757k ± 0%  -40.48% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=128/keys=1000-12               4.888k ± 0%   2.761k ± 0%  -43.51% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=1/keys=10000-12                3.544k ± 0%   3.470k ± 0%   -2.09% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=4/keys=10000-12                3.832k ± 0%   3.605k ± 0%   -5.92% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=8/keys=10000-12                4.264k ± 0%   3.861k ± 0%   -9.45% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=16/keys=10000-12               4.888k ± 0%   4.197k ± 0%  -14.14% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=24/keys=10000-12               5.408k ± 0%   4.469k ± 0%  -17.36% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=32/keys=10000-12               5.952k ± 0%   4.745k ± 0%  -20.28% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=48/keys=10000-12               6.848k ± 0%   5.245k ± 0%  -23.41% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=64/keys=10000-12               7.784k ± 0%   5.769k ± 0%  -25.89% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=128/keys=10000-12             11.024k ± 0%   7.593k ± 0%  -31.12% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=1/keys=10000-12                3.760k ± 0%   3.698k ± 0%   -1.65% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=4/keys=10000-12                4.040k ± 0%   3.857k ± 0%   -4.53% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=8/keys=10000-12                4.400k ± 0%   4.077k ± 0%   -7.34% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=16/keys=10000-12               5.008k ± 0%   4.409k ± 0%  -11.96% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=24/keys=10000-12               5.480k ± 0%   4.649k ± 0%  -15.16% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=32/keys=10000-12               6.048k ± 0%   4.993k ± 0%  -17.44% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=48/keys=10000-12               7.056k ± 0%   5.581k ± 0%  -20.90% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=64/keys=10000-12               7.776k ± 0%   5.913k ± 0%  -23.96% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=128/keys=10000-12             11.008k ± 0%   7.693k ± 0%  -30.11% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=1/keys=10000-12                4.272k ± 0%   4.214k ± 0%   -1.36% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=4/keys=10000-12                4.528k ± 0%   4.357k ± 0%   -3.78% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=8/keys=10000-12                4.768k ± 0%   4.473k ± 0%   -6.19% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=16/keys=10000-12               5.400k ± 0%   4.857k ± 0%  -10.06% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=24/keys=10000-12               5.912k ± 0%   5.137k ± 0%  -13.11% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=32/keys=10000-12               6.368k ± 0%   5.393k ± 0%  -15.31% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=48/keys=10000-12               7.272k ± 0%   5.885k ± 0%  -19.07% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=64/keys=10000-12               8.000k ± 0%   6.245k ± 0%  -21.94% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=128/keys=10000-12             10.992k ± 0%   7.881k ± 0%  -28.30% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=1/keys=100000-12               34.33k ± 0%   34.23k ± 0%   -0.29% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=4/keys=100000-12               34.54k ± 0%   34.24k ± 0%   -0.87% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=8/keys=100000-12               35.13k ± 0%   34.57k ± 0%   -1.58% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=16/keys=100000-12              36.03k ± 0%   35.04k ± 0%   -2.76% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=24/keys=100000-12              37.01k ± 0%   35.60k ± 0%   -3.80% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=32/keys=100000-12              37.78k ± 0%   35.96k ± 0%   -4.82% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=48/keys=100000-12              39.31k ± 0%   36.74k ± 0%   -6.55% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=64/keys=100000-12              40.92k ± 0%   37.69k ± 0%   -7.91% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=128/keys=100000-12             46.19k ± 0%   40.45k ± 0%  -12.44% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=1/keys=100000-12               36.62k ± 0%   36.55k ± 0%   -0.20% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=4/keys=100000-12               37.26k ± 0%   37.01k ± 0%   -0.65% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=8/keys=100000-12               37.44k ± 0%   36.99k ± 0%   -1.19% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=16/keys=100000-12              38.42k ± 0%   37.62k ± 0%   -2.08% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=24/keys=100000-12              39.09k ± 0%   37.95k ± 0%   -2.92% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=32/keys=100000-12              39.68k ± 0%   38.21k ± 0%   -3.70% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=48/keys=100000-12              41.24k ± 0%   39.18k ± 0%   -5.00% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=64/keys=100000-12              42.58k ± 0%   39.93k ± 0%   -6.23% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=128/keys=100000-12             47.26k ± 0%   42.47k ± 0%  -10.15% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=1/keys=100000-12               41.33k ± 0%   41.26k ± 0%   -0.16% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=4/keys=100000-12               41.70k ± 0%   41.49k ± 0%   -0.50% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=8/keys=100000-12               42.06k ± 0%   41.69k ± 0%   -0.88% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=16/keys=100000-12              42.73k ± 0%   42.05k ± 0%   -1.60% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=24/keys=100000-12              43.36k ± 0%   42.37k ± 0%   -2.29% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=32/keys=100000-12              44.16k ± 0%   42.87k ± 0%   -2.91% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=48/keys=100000-12              45.62k ± 0%   43.76k ± 0%   -4.07% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=64/keys=100000-12              46.86k ± 0%   44.48k ± 0%   -5.08% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=128/keys=100000-12             51.22k ± 0%   46.91k ± 0%   -8.41% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=1/keys=1000000-12              339.8k ± 0%   339.7k ± 0%   -0.03% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=4/keys=1000000-12              340.4k ± 0%   340.0k ± 0%   -0.12% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=8/keys=1000000-12              341.1k ± 0%   340.4k ± 0%   -0.21% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=16/keys=1000000-12             342.2k ± 0%   340.9k ± 0%   -0.38% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=24/keys=1000000-12             343.9k ± 0%   342.0k ± 0%   -0.55% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=32/keys=1000000-12             345.0k ± 0%   342.6k ± 0%   -0.71% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=48/keys=1000000-12             347.2k ± 0%   343.6k ± 0%   -1.03% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=64/keys=1000000-12             348.9k ± 0%   344.4k ± 0%   -1.30% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=128/keys=1000000-12            357.4k ± 0%   349.1k ± 0%   -2.32% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=1/keys=1000000-12              365.6k ± 0%   365.5k ± 0%   -0.02% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=4/keys=1000000-12              366.1k ± 0%   365.8k ± 0%   -0.08% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=8/keys=1000000-12              366.1k ± 0%   365.6k ± 0%   -0.15% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=16/keys=1000000-12             367.3k ± 0%   366.3k ± 0%   -0.27% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=24/keys=1000000-12             369.2k ± 0%   367.8k ± 0%   -0.39% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=32/keys=1000000-12             369.3k ± 0%   367.4k ± 0%   -0.51% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=48/keys=1000000-12             371.6k ± 0%   368.9k ± 0%   -0.72% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=64/keys=1000000-12             373.5k ± 0%   369.9k ± 0%   -0.94% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=128/keys=1000000-12            380.1k ± 0%   373.7k ± 0%   -1.69% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=1/keys=1000000-12              411.8k ± 0%   411.8k ± 0%   -0.02% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=4/keys=1000000-12              412.9k ± 0%   412.6k ± 0%   -0.06% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=8/keys=1000000-12              413.7k ± 0%   413.2k ± 0%   -0.11% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=16/keys=1000000-12             414.3k ± 0%   413.4k ± 0%   -0.21% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=24/keys=1000000-12             415.5k ± 0%   414.2k ± 0%   -0.30% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=32/keys=1000000-12             416.2k ± 0%   414.6k ± 0%   -0.38% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=48/keys=1000000-12             417.6k ± 0%   415.3k ± 0%   -0.55% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=64/keys=1000000-12             418.5k ± 0%   415.6k ± 0%   -0.71% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=128/keys=1000000-12            425.8k ± 0%   420.1k ± 0%   -1.32% (p=0.000 n=10)
geomean                                                               18.98k        16.32k       -14.00%

                                                           │ bench-bpk-before.txt │        bench-bpk-after.txt         │
                                                           │       bits/key       │  bits/key   vs base                │
BBHash2BitsPerKey/gamma=1.0/partitions=1/keys=1000-12                  3.520 ± 0%   3.176 ± 0%   -9.77% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=4/keys=1000-12                  4.992 ± 0%   4.033 ± 0%  -19.21% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=8/keys=1000-12                  6.592 ± 0%   5.025 ± 0%  -23.77% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=16/keys=1000-12                 9.728 ± 0%   6.977 ± 0%  -28.28% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=24/keys=1000-12                12.160 ± 0%   8.545 ± 0%  -29.73% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=32/keys=1000-12                 14.72 ± 0%   10.27 ± 0%  -30.23% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=48/keys=1000-12                 19.84 ± 0%   13.73 ± 0%  -30.80% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=64/keys=1000-12                 23.55 ± 0%   16.13 ± 0%  -31.51% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=128/keys=1000-12                39.04 ± 0%   26.21 ± 0%  -32.86% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=1/keys=1000-12                  3.456 ± 0%   3.208 ± 0%   -7.18% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=4/keys=1000-12                  5.248 ± 0%   4.353 ± 0%  -17.05% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=8/keys=1000-12                  6.592 ± 0%   5.153 ± 0%  -21.83% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=16/keys=1000-12                 9.472 ± 0%   6.977 ± 0%  -26.34% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=24/keys=1000-12                11.900 ± 0%   8.513 ± 0%  -28.46% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=32/keys=1000-12                 14.72 ± 0%   10.27 ± 0%  -30.23% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=48/keys=1000-12                 19.84 ± 0%   13.73 ± 0%  -30.80% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=64/keys=1000-12                 23.55 ± 0%   16.13 ± 0%  -31.51% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=128/keys=1000-12                39.04 ± 0%   26.21 ± 0%  -32.86% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=1/keys=1000-12                  3.840 ± 0%   3.592 ± 0%   -6.46% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=4/keys=1000-12                  5.056 ± 0%   4.321 ± 0%  -14.54% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=8/keys=1000-12                  6.848 ± 0%   5.505 ± 0%  -19.61% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=16/keys=1000-12                 9.600 ± 0%   7.137 ± 0%  -25.66% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=24/keys=1000-12                12.160 ± 0%   8.897 ± 0%  -26.83% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=32/keys=1000-12                 15.30 ± 0%   10.91 ± 0%  -28.69% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=48/keys=1000-12                 19.84 ± 0%   13.73 ± 0%  -30.80% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=64/keys=1000-12                 23.55 ± 0%   16.13 ± 0%  -31.51% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=128/keys=1000-12                39.04 ± 0%   26.21 ± 0%  -32.86% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=1/keys=10000-12                 2.822 ± 0%   2.775 ± 0%   -1.67% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=4/keys=10000-12                 3.059 ± 0%   2.899 ± 0%   -5.23% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=8/keys=10000-12                 3.405 ± 0%   3.117 ± 0%   -8.46% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=16/keys=10000-12                3.904 ± 0%   3.411 ± 0%  -12.63% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=24/keys=10000-12                4.320 ± 0%   3.655 ± 0%  -15.39% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=32/keys=10000-12                4.755 ± 0%   3.901 ± 0%  -17.96% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=48/keys=10000-12                5.472 ± 0%   4.352 ± 0%  -20.47% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=64/keys=10000-12                6.221 ± 0%   4.822 ± 0%  -22.49% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=128/keys=10000-12               8.813 ± 0%   6.487 ± 0%  -26.39% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=1/keys=10000-12                 2.995 ± 0%   2.958 ± 0%   -1.24% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=4/keys=10000-12                 3.226 ± 0%   3.101 ± 0%   -3.87% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=8/keys=10000-12                 3.514 ± 0%   3.290 ± 0%   -6.37% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=16/keys=10000-12                4.000 ± 0%   3.581 ± 0%  -10.48% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=24/keys=10000-12                4.378 ± 0%   3.799 ± 0%  -13.23% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=32/keys=10000-12                4.832 ± 0%   4.099 ± 0%  -15.17% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=48/keys=10000-12                5.638 ± 0%   4.621 ± 0%  -18.04% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=64/keys=10000-12                6.214 ± 0%   4.938 ± 0%  -20.53% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=128/keys=10000-12               8.800 ± 0%   6.566 ± 0%  -25.39% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=1/keys=10000-12                 3.405 ± 0%   3.370 ± 0%   -1.03% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=4/keys=10000-12                 3.616 ± 0%   3.501 ± 0%   -3.18% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=8/keys=10000-12                 3.808 ± 0%   3.607 ± 0%   -5.28% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=16/keys=10000-12                4.314 ± 0%   3.939 ± 0%   -8.69% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=24/keys=10000-12                4.723 ± 0%   4.189 ± 0%  -11.31% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=32/keys=10000-12                5.088 ± 0%   4.419 ± 0%  -13.15% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=48/keys=10000-12                5.811 ± 0%   4.864 ± 0%  -16.30% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=64/keys=10000-12                6.394 ± 0%   5.203 ± 0%  -18.63% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=128/keys=10000-12               8.787 ± 0%   6.717 ± 0%  -23.56% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=1/keys=100000-12                2.745 ± 0%   2.738 ± 0%   -0.26% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=4/keys=100000-12                2.762 ± 0%   2.740 ± 0%   -0.80% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=8/keys=100000-12                2.810 ± 0%   2.769 ± 0%   -1.46% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=16/keys=100000-12               2.882 ± 0%   2.808 ± 0%   -2.57% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=24/keys=100000-12               2.960 ± 0%   2.856 ± 0%   -3.51% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=32/keys=100000-12               3.022 ± 0%   2.887 ± 0%   -4.47% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=48/keys=100000-12               3.144 ± 0%   2.955 ± 0%   -6.01% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=64/keys=100000-12               3.273 ± 0%   3.036 ± 0%   -7.24% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=128/keys=100000-12              3.695 ± 0%   3.277 ± 0%  -11.31% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=1/keys=100000-12                2.929 ± 0%   2.924 ± 0%   -0.17% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=4/keys=100000-12                2.980 ± 0%   2.963 ± 0%   -0.57% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=8/keys=100000-12                2.995 ± 0%   2.962 ± 0%   -1.10% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=16/keys=100000-12               3.073 ± 0%   3.015 ± 0%   -1.89% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=24/keys=100000-12               3.126 ± 0%   3.044 ± 0%   -2.62% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=32/keys=100000-12               3.174 ± 0%   3.068 ± 0%   -3.34% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=48/keys=100000-12               3.299 ± 0%   3.150 ± 0%   -4.52% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=64/keys=100000-12               3.406 ± 0%   3.215 ± 0%   -5.61% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=128/keys=100000-12              3.780 ± 0%   3.439 ± 0%   -9.02% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=1/keys=100000-12                3.305 ± 0%   3.301 ± 0%   -0.12% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=4/keys=100000-12                3.335 ± 0%   3.321 ± 0%   -0.42% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=8/keys=100000-12                3.364 ± 0%   3.338 ± 0%   -0.77% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=16/keys=100000-12               3.418 ± 0%   3.369 ± 0%   -1.43% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=24/keys=100000-12               3.468 ± 0%   3.397 ± 0%   -2.05% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=32/keys=100000-12               3.532 ± 0%   3.440 ± 0%   -2.60% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=48/keys=100000-12               3.649 ± 0%   3.516 ± 0%   -3.64% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=64/keys=100000-12               3.748 ± 0%   3.580 ± 0%   -4.48% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=128/keys=100000-12              4.097 ± 0%   3.794 ± 0%   -7.40% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=1/keys=1000000-12               2.718 ± 0%   2.717 ± 0%   -0.04% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=4/keys=1000000-12               2.723 ± 0%   2.720 ± 0%   -0.11% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=8/keys=1000000-12               2.729 ± 0%   2.724 ± 0%   -0.18% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=16/keys=1000000-12              2.737 ± 0%   2.727 ± 0%   -0.37% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=24/keys=1000000-12              2.751 ± 0%   2.737 ± 0%   -0.51% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=32/keys=1000000-12              2.760 ± 0%   2.742 ± 0%   -0.65% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=48/keys=1000000-12              2.778 ± 0%   2.751 ± 0%   -0.97% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=64/keys=1000000-12              2.791 ± 0%   2.757 ± 0%   -1.22% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.0/partitions=128/keys=1000000-12             2.859 ± 0%   2.797 ± 0%   -2.17% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=1/keys=1000000-12               2.925 ± 0%   2.924 ± 0%   -0.03% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=4/keys=1000000-12               2.929 ± 0%   2.926 ± 0%   -0.10% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=8/keys=1000000-12               2.929 ± 0%   2.925 ± 0%   -0.14% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=16/keys=1000000-12              2.938 ± 0%   2.931 ± 0%   -0.24% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=24/keys=1000000-12              2.954 ± 0%   2.943 ± 0%   -0.37% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=32/keys=1000000-12              2.954 ± 0%   2.941 ± 0%   -0.44% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=48/keys=1000000-12              2.972 ± 0%   2.953 ± 0%   -0.64% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=64/keys=1000000-12              2.988 ± 0%   2.962 ± 0%   -0.87% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=1.5/partitions=128/keys=1000000-12             3.041 ± 0%   2.993 ± 0%   -1.58% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=1/keys=1000000-12               3.295 ± 0%   3.294 ± 0%   -0.03% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=4/keys=1000000-12               3.303 ± 0%   3.301 ± 0%   -0.06% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=8/keys=1000000-12               3.309 ± 0%   3.306 ± 0%   -0.09% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=16/keys=1000000-12              3.314 ± 0%   3.308 ± 0%   -0.18% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=24/keys=1000000-12              3.324 ± 0%   3.315 ± 0%   -0.27% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=32/keys=1000000-12              3.330 ± 0%   3.318 ± 0%   -0.36% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=48/keys=1000000-12              3.341 ± 0%   3.324 ± 0%   -0.51% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=64/keys=1000000-12              3.348 ± 0%   3.327 ± 0%   -0.63% (p=0.000 n=10)
BBHash2BitsPerKey/gamma=2.0/partitions=128/keys=1000000-12             3.406 ± 0%   3.365 ± 0%   -1.20% (p=0.000 n=10)
geomean                                                                4.788        4.252       -11.20%
```
