### PR TITLE
Chunks() and Keys() functions along with their respective tests

### DIFF
--- a/bbhash_iter.go
+++ b/bbhash_iter.go
@@ -29,6 +29,5 @@ func Keys(hashFunc func([]byte) uint64, chunks iter.Seq[[]byte]) []uint64 {
 	for c := range chunks {
 		keys = append(keys, hashFunc(c))
 	}
-
 	return keys
 }

--- a/bbhash_iter.go
+++ b/bbhash_iter.go
@@ -1,57 +1,33 @@
 package bbhash
 
 import (
-	"crypto/sha256"
-	"encoding/binary"
 	"io"
 	"iter"
-
-	"github.com/relab/bbhash/internal/fast"
 )
 
-type BBHashSeq struct {
-	bits       []*bitVector
-	ranks      []uint64
-	reverseMap []uint64
-	hashFunc   int // Use int instead of bool incase there can be more hash functions tested than fasthash64 and SHA256. 0 = hash64, 1 = SHA256.
-	MaxLevel   int
-}
-
 // Find the chunks from slow memory
-// Currently only takes the whole sequence of input and crashes if it's not able to fit everything in the buffer.
+// Chunks returns smaller chunks of data given a reader with some data already being read and with the buffer size.
 func ReadChunks(readerInfo io.Reader, bufSz int) iter.Seq[[]byte] {
 	return func(yield func([]byte) bool) {
-		i := 0
+		buffer := make([]byte, bufSz)
 		for {
 			// Create buffer and read the input into it for a certain range of bytes
-			buffer := make([]byte, bufSz)
-			_, err := readerInfo.Read(buffer)
+			n, err := readerInfo.Read(buffer)
 			if err != nil {
 				return
 			}
-			i++
-			if !yield(buffer) {
+			if !yield(buffer[:n]) {
 				return
 			}
 		}
 	}
 }
 
-// Int = hashfunc, iter.Seq chunks.
-// Recieves chunks from chunks() and converts them to keys and returns them as []uint64
-func Keys(hashFunc int, chunks iter.Seq[[]byte]) []uint64 {
+// Keys returns the hashes of the chunks using the provided hash function
+func Keys(hashFunc func([]byte) uint64, chunks iter.Seq[[]byte]) []uint64 {
 	var keys []uint64
-	if hashFunc == 0 {
-		for c := range chunks {
-			keys = append(keys, fast.Hash64(1, c)) //1 is just a magic number
-		}
-	} else {
-		for c := range chunks {
-			h := sha256.New()
-			h.Write(c)
-			s := binary.LittleEndian.Uint64(h.Sum(nil))
-			keys = append(keys, s)
-		}
+	for c := range chunks {
+		keys = append(keys, hashFunc(c))
 	}
 
 	return keys

--- a/bbhash_iter.go
+++ b/bbhash_iter.go
@@ -1,0 +1,58 @@
+package bbhash
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"io"
+	"iter"
+
+	"github.com/relab/bbhash/internal/fast"
+)
+
+type BBHashSeq struct {
+	bits       []*bitVector
+	ranks      []uint64
+	reverseMap []uint64
+	hashFunc   int // Use int instead of bool incase there can be more hash functions tested than fasthash64 and SHA256. 0 = hash64, 1 = SHA256.
+	MaxLevel   int
+}
+
+// Find the chunks from slow memory
+// Currently only takes the whole sequence of input and crashes if it's not able to fit everything in the buffer.
+func ReadChunks(readerInfo io.Reader, bufSz int) iter.Seq[[]byte] {
+	return func(yield func([]byte) bool) {
+		i := 0
+		for {
+			// Create buffer and read the input into it for a certain range of bytes
+			buffer := make([]byte, bufSz)
+			_, err := readerInfo.Read(buffer)
+			if err != nil {
+				return
+			}
+			i++
+			if !yield(buffer) {
+				return
+			}
+		}
+	}
+}
+
+// Int = hashfunc, iter.Seq chunks.
+// Recieves chunks from chunks() and converts them to keys and returns them as []uint64
+func Keys(hashFunc int, chunks iter.Seq[[]byte]) []uint64 {
+	var keys []uint64
+	if hashFunc == 0 {
+		for c := range chunks {
+			keys = append(keys, fast.Hash64(1, c)) //1 is just a magic number
+		}
+	} else {
+		for c := range chunks {
+			h := sha256.New()
+			h.Write(c)
+			s := binary.LittleEndian.Uint64(h.Sum(nil))
+			keys = append(keys, s)
+		}
+	}
+
+	return keys
+}

--- a/bbhash_iter_test.go
+++ b/bbhash_iter_test.go
@@ -15,7 +15,6 @@ import (
 
 // String taken from https://www.lipsum.com/
 const input string = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
-const word string = "Hello"
 
 func TestChunks(t *testing.T) {
 	// Read the string and get the resulting bytes from the Chunks() method
@@ -53,24 +52,24 @@ func TestHashKeysFromChunks(t *testing.T) {
 	tests := []struct {
 		name      string
 		hashFunc  func([]byte) uint64
-		word      string
+		in        string
 		chunkSize int
 	}{
-		{name: "FashHash", hashFunc: fastHashFunc, word: word, chunkSize: 4},
-		{name: "FashHash", hashFunc: fastHashFunc, word: word, chunkSize: 8},
-		{name: "SHA256", hashFunc: sha256hashFunc, word: word, chunkSize: 4},
-		{name: "SHA256", hashFunc: sha256hashFunc, word: word, chunkSize: 8},
-		{name: "LongFast", hashFunc: sha256hashFunc, word: input, chunkSize: 128},
-		{name: "LongSHA", hashFunc: sha256hashFunc, word: input, chunkSize: 128},
+		{name: "FashHash", hashFunc: fastHashFunc, in: input[:5], chunkSize: 4},
+		{name: "FashHash", hashFunc: fastHashFunc, in: input[:5], chunkSize: 8},
+		{name: "SHA256", hashFunc: sha256hashFunc, in: input[:5], chunkSize: 4},
+		{name: "SHA256", hashFunc: sha256hashFunc, in: input[:5], chunkSize: 8},
+		{name: "LongFast", hashFunc: fastHashFunc, in: input, chunkSize: 128},
+		{name: "LongSHA", hashFunc: sha256hashFunc, in: input, chunkSize: 128},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Prepare the expected hashed keys
-			wantHashedKeys := CollectFunc(slices.Chunk([]byte(test.word), test.chunkSize), func(v []byte) uint64 {
+			wantHashedKeys := CollectFunc(slices.Chunk([]byte(test.in), test.chunkSize), func(v []byte) uint64 {
 				return test.hashFunc(v)
 			})
 
-			r := strings.NewReader(test.word)
+			r := strings.NewReader(test.in)
 			chunks := bbhash.ReadChunks(r, test.chunkSize)
 			gotHashedKeys := bbhash.Keys(test.hashFunc, chunks)
 

--- a/bbhash_iter_test.go
+++ b/bbhash_iter_test.go
@@ -1,0 +1,150 @@
+package bbhash_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/relab/bbhash"
+	"github.com/relab/bbhash/internal/fast"
+)
+
+func TestChunks(t *testing.T) {
+	input := "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+	// Read the string and get the resulting bytes from the Chunks() method
+	r := strings.NewReader(input)
+	bufSz := 128
+	wantChunks := slices.Collect(slices.Chunk([]byte(input), bufSz))
+
+	i := 0
+	for got := range bbhash.ReadChunks(r, bufSz) {
+		// Remove empty slots to make the "got" and "want" chunks to be the same,
+		//  in case the whole chunk of bytes is not used.
+		got = bytes.Trim(got, "\x00")
+		if diff := cmp.Diff(got, wantChunks[i]); diff != "" {
+			t.Errorf("Chunks() (-got +want)\n%s", diff)
+		}
+		i++
+	}
+}
+
+func TestHashKeysFromChunksSingleWord(t *testing.T) {
+	word := "Hello"
+	hashFunc := 0 // 0 = Fasthash, 1 = sha256
+	r := strings.NewReader(word)
+	chunks := bbhash.ReadChunks(r, 8)
+
+	gotHashedKeys := bbhash.Keys(hashFunc, chunks)
+
+	// As we are dealing with an append on wordByte, som bytes are removed...
+	// ...from the initial creation such that wordByte and chunks have the same length
+	wordByte := make([]byte, 3)
+	wordByte = append([]byte(word), wordByte...)
+	wantHashedKeys := []uint64{fast.Hash64(1, wordByte)}
+
+	for i := range wantHashedKeys {
+		if diff := cmp.Diff(gotHashedKeys[i], wantHashedKeys[i]); diff != "" {
+			t.Errorf("Keys(): (-got +want) \n%s", diff)
+		}
+	}
+}
+
+func TestHashKeysFromChunksSingleWordSHA256(t *testing.T) {
+	word := "Hello"
+	hashFunc := 1 // 0 = Fasthash, 1 = sha256
+	r := strings.NewReader(word)
+	chunks := bbhash.ReadChunks(r, 8)
+
+	gotHashedKeys := bbhash.Keys(hashFunc, chunks)
+
+	// As we are dealing with an append on wordByte, som bytes are removed...
+	// ...from the initial creation such that wordByte and chunks have the same length
+	wordByte := make([]byte, 3)
+	wordByte = append([]byte(word), wordByte...)
+	h := sha256.New()
+	h.Write(wordByte)
+	s := binary.LittleEndian.Uint64(h.Sum(nil))
+	wantHashedKeys := []uint64{s}
+
+	for i := range wantHashedKeys {
+		if diff := cmp.Diff(gotHashedKeys[i], wantHashedKeys[i]); diff != "" {
+			t.Errorf("Keys(): (-got +want) \n%s", diff)
+		}
+	}
+}
+
+func TestHashKeysFromChunksLongerWords(t *testing.T) {
+	// String taken from https://www.lipsum.com/
+	input := "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+	hashFunc := 0 // 0 = Fasthash, 1 = sha256
+	bufSz := 128
+
+	r := strings.NewReader(input)
+	chunks := bbhash.ReadChunks(r, bufSz)
+	gotKeyHashes := bbhash.Keys(hashFunc, chunks)
+
+	wantChunks := slices.Collect(slices.Chunk([]byte(input), bufSz))
+	wantKeyHashes := []uint64{}
+
+	// Last hash element might containt zeroes, meaning we have to append some zeroes  to the original input
+	// so that both will produce the same hash
+	if len(wantChunks[len(wantChunks)-1]) != bufSz {
+		for i := len(wantChunks[len(wantChunks)-1]); i < bufSz; i++ {
+			wantChunks[len(wantChunks)-1] = append(wantChunks[len(wantChunks)-1][:], 0)
+		}
+	}
+
+	// Hash the keys using fast.Hash64() using 1 as the seed, which was chosen arbitrarily, to compare to the keys from Keys()
+	for i := range wantChunks {
+		wordHash := fast.Hash64(1, []byte(wantChunks[i]))
+		wantKeyHashes = append(wantKeyHashes, wordHash)
+	}
+
+	for i := range wantKeyHashes {
+		if diff := cmp.Diff(gotKeyHashes[i], wantKeyHashes[i]); diff != "" {
+			t.Errorf("Keys() (-got +want) \n%s", diff)
+		}
+
+	}
+}
+
+func TestHashKeysFromChunksLongerWordsSHA256(t *testing.T) {
+	// String taken from https://www.lipsum.com/
+	input := "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+	hashFunc := 1 // 0 = Fasthash, 1 = sha256
+	bufSz := 128
+
+	r := strings.NewReader(input)
+	chunks := bbhash.ReadChunks(r, bufSz)
+	gotKeyHashes := bbhash.Keys(hashFunc, chunks)
+
+	wantChunks := slices.Collect(slices.Chunk([]byte(input), bufSz))
+	wantKeyHashes := []uint64{}
+
+	// Last hash element might containt zeroes, meaning we have to append some zeroes  to the original input
+	// so that both will produce the same hash
+	if len(wantChunks[len(wantChunks)-1]) != bufSz {
+		for i := len(wantChunks[len(wantChunks)-1]); i < bufSz; i++ {
+			wantChunks[len(wantChunks)-1] = append(wantChunks[len(wantChunks)-1][:], 0)
+		}
+	}
+
+	// Hash the keys using SHA256 and add them to the slice to compare to hte keys from Keys()
+	for i := range wantChunks {
+		h := sha256.New()
+		h.Write(wantChunks[i])
+		s := binary.LittleEndian.Uint64(h.Sum(nil))
+		wantKeyHashes = append(wantKeyHashes, s)
+	}
+
+	for i := range wantKeyHashes {
+		if diff := cmp.Diff(gotKeyHashes[i], wantKeyHashes[i]); diff != "" {
+			t.Errorf("Keys() (-got +want) \n%s", diff)
+		}
+
+	}
+}

--- a/bbhash_iter_test.go
+++ b/bbhash_iter_test.go
@@ -1,9 +1,9 @@
 package bbhash_test
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
+	"iter"
 	"slices"
 	"strings"
 	"testing"
@@ -13,8 +13,11 @@ import (
 	"github.com/relab/bbhash/internal/fast"
 )
 
+// String taken from https://www.lipsum.com/
+const input string = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+const word string = "Hello"
+
 func TestChunks(t *testing.T) {
-	input := "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
 	// Read the string and get the resulting bytes from the Chunks() method
 	r := strings.NewReader(input)
 	bufSz := 128
@@ -22,9 +25,6 @@ func TestChunks(t *testing.T) {
 
 	i := 0
 	for got := range bbhash.ReadChunks(r, bufSz) {
-		// Remove empty slots to make the "got" and "want" chunks to be the same,
-		//  in case the whole chunk of bytes is not used.
-		got = bytes.Trim(got, "\x00")
 		if diff := cmp.Diff(got, wantChunks[i]); diff != "" {
 			t.Errorf("Chunks() (-got +want)\n%s", diff)
 		}
@@ -32,119 +32,51 @@ func TestChunks(t *testing.T) {
 	}
 }
 
-func TestHashKeysFromChunksSingleWord(t *testing.T) {
-	word := "Hello"
-	hashFunc := 0 // 0 = Fasthash, 1 = sha256
-	r := strings.NewReader(word)
-	chunks := bbhash.ReadChunks(r, 8)
-
-	gotHashedKeys := bbhash.Keys(hashFunc, chunks)
-
-	// As we are dealing with an append on wordByte, som bytes are removed...
-	// ...from the initial creation such that wordByte and chunks have the same length
-	wordByte := make([]byte, 3)
-	wordByte = append([]byte(word), wordByte...)
-	wantHashedKeys := []uint64{fast.Hash64(1, wordByte)}
-
-	for i := range wantHashedKeys {
-		if diff := cmp.Diff(gotHashedKeys[i], wantHashedKeys[i]); diff != "" {
-			t.Errorf("Keys(): (-got +want) \n%s", diff)
-		}
-	}
-}
-
-func TestHashKeysFromChunksSingleWordSHA256(t *testing.T) {
-	word := "Hello"
-	hashFunc := 1 // 0 = Fasthash, 1 = sha256
-	r := strings.NewReader(word)
-	chunks := bbhash.ReadChunks(r, 8)
-
-	gotHashedKeys := bbhash.Keys(hashFunc, chunks)
-
-	// As we are dealing with an append on wordByte, som bytes are removed...
-	// ...from the initial creation such that wordByte and chunks have the same length
-	wordByte := make([]byte, 3)
-	wordByte = append([]byte(word), wordByte...)
+var sha256hashFunc = func(buf []byte) uint64 {
 	h := sha256.New()
-	h.Write(wordByte)
-	s := binary.LittleEndian.Uint64(h.Sum(nil))
-	wantHashedKeys := []uint64{s}
-
-	for i := range wantHashedKeys {
-		if diff := cmp.Diff(gotHashedKeys[i], wantHashedKeys[i]); diff != "" {
-			t.Errorf("Keys(): (-got +want) \n%s", diff)
-		}
-	}
+	h.Write(buf)
+	return binary.LittleEndian.Uint64(h.Sum(nil))
 }
 
-func TestHashKeysFromChunksLongerWords(t *testing.T) {
-	// String taken from https://www.lipsum.com/
-	input := "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
-	hashFunc := 0 // 0 = Fasthash, 1 = sha256
-	bufSz := 128
-
-	r := strings.NewReader(input)
-	chunks := bbhash.ReadChunks(r, bufSz)
-	gotKeyHashes := bbhash.Keys(hashFunc, chunks)
-
-	wantChunks := slices.Collect(slices.Chunk([]byte(input), bufSz))
-	wantKeyHashes := []uint64{}
-
-	// Last hash element might containt zeroes, meaning we have to append some zeroes  to the original input
-	// so that both will produce the same hash
-	if len(wantChunks[len(wantChunks)-1]) != bufSz {
-		for i := len(wantChunks[len(wantChunks)-1]); i < bufSz; i++ {
-			wantChunks[len(wantChunks)-1] = append(wantChunks[len(wantChunks)-1][:], 0)
-		}
-	}
-
-	// Hash the keys using fast.Hash64() using 1 as the seed, which was chosen arbitrarily, to compare to the keys from Keys()
-	for i := range wantChunks {
-		wordHash := fast.Hash64(1, []byte(wantChunks[i]))
-		wantKeyHashes = append(wantKeyHashes, wordHash)
-	}
-
-	for i := range wantKeyHashes {
-		if diff := cmp.Diff(gotKeyHashes[i], wantKeyHashes[i]); diff != "" {
-			t.Errorf("Keys() (-got +want) \n%s", diff)
-		}
-
-	}
+var fastHashFunc = func(buf []byte) uint64 {
+	return fast.Hash64(uint64(123), buf)
 }
 
-func TestHashKeysFromChunksLongerWordsSHA256(t *testing.T) {
-	// String taken from https://www.lipsum.com/
-	input := "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
-	hashFunc := 1 // 0 = Fasthash, 1 = sha256
-	bufSz := 128
-
-	r := strings.NewReader(input)
-	chunks := bbhash.ReadChunks(r, bufSz)
-	gotKeyHashes := bbhash.Keys(hashFunc, chunks)
-
-	wantChunks := slices.Collect(slices.Chunk([]byte(input), bufSz))
-	wantKeyHashes := []uint64{}
-
-	// Last hash element might containt zeroes, meaning we have to append some zeroes  to the original input
-	// so that both will produce the same hash
-	if len(wantChunks[len(wantChunks)-1]) != bufSz {
-		for i := len(wantChunks[len(wantChunks)-1]); i < bufSz; i++ {
-			wantChunks[len(wantChunks)-1] = append(wantChunks[len(wantChunks)-1][:], 0)
-		}
+func CollectFunc[I, O any](seq iter.Seq[I], f func(I) O) (o []O) {
+	for v := range seq {
+		o = append(o, f(v))
 	}
+	return
+}
 
-	// Hash the keys using SHA256 and add them to the slice to compare to hte keys from Keys()
-	for i := range wantChunks {
-		h := sha256.New()
-		h.Write(wantChunks[i])
-		s := binary.LittleEndian.Uint64(h.Sum(nil))
-		wantKeyHashes = append(wantKeyHashes, s)
+func TestHashKeysFromChunks(t *testing.T) {
+	tests := []struct {
+		name      string
+		hashFunc  func([]byte) uint64
+		word      string
+		chunkSize int
+	}{
+		{name: "FashHash", hashFunc: fastHashFunc, word: word, chunkSize: 4},
+		{name: "FashHash", hashFunc: fastHashFunc, word: word, chunkSize: 8},
+		{name: "SHA256", hashFunc: sha256hashFunc, word: word, chunkSize: 4},
+		{name: "SHA256", hashFunc: sha256hashFunc, word: word, chunkSize: 8},
+		{name: "LongFast", hashFunc: sha256hashFunc, word: input, chunkSize: 128},
+		{name: "LongSHA", hashFunc: sha256hashFunc, word: input, chunkSize: 128},
 	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Prepare the expected hashed keys
+			wantHashedKeys := CollectFunc(slices.Chunk([]byte(test.word), test.chunkSize), func(v []byte) uint64 {
+				return test.hashFunc(v)
+			})
 
-	for i := range wantKeyHashes {
-		if diff := cmp.Diff(gotKeyHashes[i], wantKeyHashes[i]); diff != "" {
-			t.Errorf("Keys() (-got +want) \n%s", diff)
-		}
+			r := strings.NewReader(test.word)
+			chunks := bbhash.ReadChunks(r, test.chunkSize)
+			gotHashedKeys := bbhash.Keys(test.hashFunc, chunks)
 
+			if diff := cmp.Diff(gotHashedKeys, wantHashedKeys); diff != "" {
+				t.Errorf("Keys(): (-got +want) \n%s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Two functions are added, along with some tests: 

* `Chunks()`, with a paramater `bufSz` that allows for size adjustments for the buffer used in the function.
    - `TestChunks()` simply checks if it is able to read a string as it should be, even if it has to split the input up into several chunks.
    

* `Keys()`, also has an adjustable variable, `hashFunc`, that allows to change which hash function the user wants to use. Currently, there is only `fast.Hash64()` and `SHA256` to choose from. But `hashFunc` is kept as an `int` and not `bool` to leave room for other hash functions to be integrated in the future.
    - `TestHashKeysFromChunksSingleWord()`, checks if `Keys()` works with `"Hello"` as an input string, using `fast.hash64`.
    - `TestHashKeysFromChunksLongerWords()`, works similarly just with a longer input to make sure that Keys() works even if there are more than one chunk, using  `fast.hash64`.
    -  `TestHashKeysFromChunksSingleWord()` and `TestHashKeysFromChunksLongerWords()` do the same as the above tests but uses `SHA256` as the hashing algorithm instead.
 


Fixes #22 